### PR TITLE
Add OpenSearch support

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="/style.css" />
   <link rel="home" href="/" />
   <link rel="icon" href="/favicon.png" type="image/png" />
+  <link rel="search" type="application/opensearchdescription+xml" title="&udm=14" href="/search.xml" />
   <title>&udm=14 | the enshittification Konami code</title>
   <meta name="description" content="A quick way to get an AI-free search without any extra work." />
   <meta name="HandheldFriendly" content="True" />

--- a/search.xml
+++ b/search.xml
@@ -1,0 +1,10 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>&amp;udm=14</ShortName>
+  <Description>the enshittification Konami code</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="512" height="512" type="image/png">https://udm14.com/favicon.png</Image>
+  <Url type="text/html" template="https://www.google.com/search?q={searchTerms}&amp;udm=14"/>
+  <Url type="application/x-suggestions+json" template="https://www.google.com/complete/search?client=firefox&amp;q={searchTerms}"/>
+  <moz:SearchForm>https://www.google.com/search</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
This PR provides OpenSearch support, which allows web browsers to natively integrate &udm=14 within their search bars.